### PR TITLE
Feature/finetuning offline data logging

### DIFF
--- a/components/core/DeviceTypes/DeviceTypeRecord.h
+++ b/components/core/DeviceTypes/DeviceTypeRecord.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 #include "RaftArduino.h"
 #include "RaftBus.h"
+#include "RaftUtils.h"
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /// @brief Get decoded data record
@@ -70,18 +71,25 @@ public:
             return devInfoJson ? String(devInfoJson) : "{}";
         }
 
+        auto appendStringField = [](String& json, const char* name, const char* value)
+        {
+            if (!value)
+                return;
+            json += "\"";
+            json += name;
+            json += "\":\"";
+            json += Raft::escapeString(value, true);
+            json += "\",";
+        };
+
         // Form JSON string
         String devTypeInfo = "{";
-        if (deviceType)
-            devTypeInfo += "\"type\":\"" + String(deviceType) + "\",";
-        if (addresses)
-            devTypeInfo += "\"addr\":\"" + String(addresses) + "\",";
-        if (detectionValues)
-            devTypeInfo += "\"det\":\"" + String(detectionValues) + "\",";
-        if (initValues)
-            devTypeInfo += "\"init\":\"" + String(initValues) + "\",";
+        appendStringField(devTypeInfo, "type", deviceType);
+        appendStringField(devTypeInfo, "addr", addresses);
+        appendStringField(devTypeInfo, "det", detectionValues);
+        appendStringField(devTypeInfo, "init", initValues);
         if (pollInfo)
-            devTypeInfo += "\"poll\":\"" + String(pollInfo) + "\",";
+            devTypeInfo += "\"poll\":" + String(pollInfo) + ",";
         if (devInfoJson)
             devTypeInfo += "\"info\":" + String(devInfoJson) + ",";
         devTypeInfo += "\"pollSize\":" + String(pollDataSizeBytes);

--- a/components/core/NetworkSystem/NetworkSystem.cpp
+++ b/components/core/NetworkSystem/NetworkSystem.cpp
@@ -174,6 +174,13 @@ bool NetworkSystem::setup(const NetworkSettings& networkSettings)
 
 void NetworkSystem::loop()
 {
+    if (_pendingWiFiDisconnectWarn)
+    {
+        _pendingWiFiDisconnectWarn = false;
+        LOG_W(MODULE_PREFIX, "WiFi disconnected, retry to connect to the AP retries %d",
+                _pendingWiFiDisconnectWarnRetries);
+    }
+
     // Get WiFi RSSI value if connected
     // Don't set WIFI_RSSI_CHECK_MS too low as getting AP info takes ~2ms
     if (Raft::isTimeout(millis(), _wifiRSSILastMs, WIFI_RSSI_CHECK_MS))
@@ -429,9 +436,27 @@ bool NetworkSystem::startWifi()
     }
 
     // Attach event handlers
-    esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID, &networkEventHandler, nullptr, nullptr);
-    esp_event_handler_instance_register(IP_EVENT, IP_EVENT_STA_GOT_IP, &networkEventHandler, nullptr, nullptr);
-    esp_event_handler_instance_register(IP_EVENT, IP_EVENT_STA_LOST_IP, &networkEventHandler, nullptr, nullptr);
+    if (!_wifiEventHandlerInstance)
+    {
+        esp_err_t regErr = esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID,
+                                &networkEventHandler, nullptr, &_wifiEventHandlerInstance);
+        if (regErr != ESP_OK)
+            LOG_E(MODULE_PREFIX, "startWifi failed to register WiFi event handler err %s (%d)", esp_err_to_name(regErr), regErr);
+    }
+    if (!_ipGotEventHandlerInstance)
+    {
+        esp_err_t regErr = esp_event_handler_instance_register(IP_EVENT, IP_EVENT_STA_GOT_IP,
+                                &networkEventHandler, nullptr, &_ipGotEventHandlerInstance);
+        if (regErr != ESP_OK)
+            LOG_E(MODULE_PREFIX, "startWifi failed to register IP got event handler err %s (%d)", esp_err_to_name(regErr), regErr);
+    }
+    if (!_ipLostEventHandlerInstance)
+    {
+        esp_err_t regErr = esp_event_handler_instance_register(IP_EVENT, IP_EVENT_STA_LOST_IP,
+                                &networkEventHandler, nullptr, &_ipLostEventHandlerInstance);
+        if (regErr != ESP_OK)
+            LOG_E(MODULE_PREFIX, "startWifi failed to register IP lost event handler err %s (%d)", esp_err_to_name(regErr), regErr);
+    }
 
     // Set storage
     esp_wifi_set_storage(WIFI_STORAGE_FLASH);
@@ -499,9 +524,30 @@ void NetworkSystem::stopWifi()
     esp_wifi_stop();
 
     // Remove event handlers
-    esp_event_handler_instance_unregister(IP_EVENT, IP_EVENT_STA_GOT_IP, nullptr);
-    esp_event_handler_instance_unregister(IP_EVENT, IP_EVENT_STA_LOST_IP, nullptr);
-    esp_event_handler_instance_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, nullptr);
+    if (_ipGotEventHandlerInstance)
+    {
+        esp_err_t unregErr = esp_event_handler_instance_unregister(IP_EVENT, IP_EVENT_STA_GOT_IP, _ipGotEventHandlerInstance);
+        if (unregErr == ESP_OK)
+            _ipGotEventHandlerInstance = nullptr;
+        else
+            LOG_W(MODULE_PREFIX, "stopWifi failed to unregister IP got event handler err %s (%d)", esp_err_to_name(unregErr), unregErr);
+    }
+    if (_ipLostEventHandlerInstance)
+    {
+        esp_err_t unregErr = esp_event_handler_instance_unregister(IP_EVENT, IP_EVENT_STA_LOST_IP, _ipLostEventHandlerInstance);
+        if (unregErr == ESP_OK)
+            _ipLostEventHandlerInstance = nullptr;
+        else
+            LOG_W(MODULE_PREFIX, "stopWifi failed to unregister IP lost event handler err %s (%d)", esp_err_to_name(unregErr), unregErr);
+    }
+    if (_wifiEventHandlerInstance)
+    {
+        esp_err_t unregErr = esp_event_handler_instance_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, _wifiEventHandlerInstance);
+        if (unregErr == ESP_OK)
+            _wifiEventHandlerInstance = nullptr;
+        else
+            LOG_W(MODULE_PREFIX, "stopWifi failed to unregister WiFi event handler err %s (%d)", esp_err_to_name(unregErr), unregErr);
+    }
 
     // Deinit WiFi
     esp_wifi_deinit();
@@ -1369,7 +1415,8 @@ void NetworkSystem::warnOnWiFiDisconnectIfEthNotConnected()
             ((_numWifiConnectRetries < 1000) && (_numWifiConnectRetries % 100) == 0) ||
             ((_numWifiConnectRetries % 1000) == 0))
         {
-            LOG_W(MODULE_PREFIX, "WiFi disconnected, retry to connect to the AP retries %d", _numWifiConnectRetries);
+            _pendingWiFiDisconnectWarnRetries = _numWifiConnectRetries;
+            _pendingWiFiDisconnectWarn = true;
         }
     }
 #endif

--- a/components/core/NetworkSystem/NetworkSystem.h
+++ b/components/core/NetworkSystem/NetworkSystem.h
@@ -162,6 +162,13 @@ private:
     // Connect retries
     int _numWifiConnectRetries = 0; 
     uint32_t _lastReconnAttemptMs = 0;
+    bool _pendingWiFiDisconnectWarn = false;
+    int _pendingWiFiDisconnectWarnRetries = 0;
+
+    // WiFi event handler instances
+    esp_event_handler_instance_t _wifiEventHandlerInstance = nullptr;
+    esp_event_handler_instance_t _ipGotEventHandlerInstance = nullptr;
+    esp_event_handler_instance_t _ipLostEventHandlerInstance = nullptr;
 
     // Retry max, -1 means try forever
     static const int WIFI_CONNECT_MAX_RETRY = -1;

--- a/devdocs/ble-wifi-pause-event-handler-fix.md
+++ b/devdocs/ble-wifi-pause-event-handler-fix.md
@@ -1,0 +1,121 @@
+# BLE WiFi Pause Event Handler Fix
+
+## Summary
+
+On 2026-05-04, intermittent crashes during Web Bluetooth connection were
+traced to the WiFi pause/resume path used when BLE connects.
+
+The fix is in `RaftCore` `NetworkSystem`: store the ESP-IDF event handler
+instance handles returned by `esp_event_handler_instance_register()` and pass
+those exact handles to `esp_event_handler_instance_unregister()` when WiFi is
+stopped for BLE coexistence.
+
+No system event task stack-size change was made.
+
+## Observed Failure
+
+The crash occurred around BLE connect/disconnect while WiFi was paused and then
+resumed. The symptoms included:
+
+- `assert failed: xQueueGenericSend queue.c:937`
+- `A stack overflow in task sys_evt`
+
+Direct formatted logging inside the ESP system event task also reproduced a
+stack overflow, confirming that `sys_evt` has very little spare stack in this
+firmware configuration. Logging from that callback must stay minimal.
+
+## Confirmed Cause
+
+`NetworkSystem::startWifi()` registered three event handlers:
+
+- `WIFI_EVENT, ESP_EVENT_ANY_ID`
+- `IP_EVENT, IP_EVENT_STA_GOT_IP`
+- `IP_EVENT, IP_EVENT_STA_LOST_IP`
+
+`NetworkSystem::stopWifi()` attempted to unregister them with `nullptr` handler
+instance arguments. In ESP-IDF 5.5.2, unregistering an instance handler requires
+the instance handle returned by `esp_event_handler_instance_register()`.
+
+The unregister calls returned `ESP_ERR_INVALID_ARG`, so each BLE pause/resume
+cycle left the previous handlers registered. Subsequent WiFi restarts
+accumulated duplicate callbacks and produced duplicate reconnect attempts.
+
+Diagnostic logs before the fix showed handler count growing from 3 to 6 after
+one BLE cycle and `esp_wifi_connect()` returning `ESP_ERR_WIFI_CONN` from a
+duplicate `WIFI_EVENT_STA_START` callback.
+
+## History
+
+The relevant commit history is:
+
+- `3bb045c8` (`Tidied up network handling`, 2023-06-30) moved network handling
+  to `esp_event_handler_instance_register(..., nullptr)`. At this point WiFi
+  pause still used `esp_wifi_disconnect()` / `esp_wifi_connect()`, so the
+  invalid unregister path was not exercised during BLE pause/resume.
+- `631be91c6991dd86f7b36a94c39cb9c094a4cddd` (`Fixed Wifi pause code`,
+  2023-07-11) changed BLE WiFi pause from `esp_wifi_disconnect()` to full
+  `stopWifi()` / `startWifi()` cycling and added the invalid instance
+  unregister calls. This is where the handler-lifecycle bug was introduced.
+- `085455d3` (`Improved logging performance over USB JTAG`, 2026-04-22)
+  changed `loggerLog()` from a heap/PSRAM-backed buffer to a 1024-byte stack
+  buffer. This did not create the handler bug, but it reduced stack margin for
+  formatted logging from low-stack tasks such as `sys_evt`.
+- RoboticalAxiom1 commit `475f7b4` (`Moved back to ESP IDF 5.5.2 until I2C
+  issue fixed`, 2026-04-23) and later `d09d30c` (`Stabilize offline data
+  logging firmware`, 2026-04-29) left the current firmware building on ESP-IDF
+  5.5.2 with the newer RaftCore logging/event behavior.
+
+The invalid unregister sequence from `631be91c` was:
+
+- `esp_event_handler_instance_register(..., nullptr)` in `startWifi()`
+- `esp_event_handler_instance_unregister(..., nullptr)` in `stopWifi()`
+
+ESP-IDF 5.5.2 did not introduce the API requirement. Local ESP-IDF 4.4.4, 5.4.1,
+and 5.5.2 all return `ESP_ERR_INVALID_ARG` when
+`esp_event_handler_instance_unregister_with()` is called with a null instance
+handle. The recent 5.5.2/6.0 migration work made this latent bug more visible,
+but the handler-lifecycle bug itself is older.
+
+Recent logging and IDF migration work changed timing and stack pressure enough that the
+same invalid handler lifecycle now reproduces as `sys_evt` stack overflows,
+watchdog panics, or duplicate WiFi reconnect attempts.
+
+## Fix
+
+`NetworkSystem` now stores the three event handler instance handles:
+
+- `_wifiEventHandlerInstance`
+- `_ipGotEventHandlerInstance`
+- `_ipLostEventHandlerInstance`
+
+On WiFi stop, each non-null handle is unregistered with its matching event
+base/event ID and then cleared on `ESP_OK`.
+
+The WiFi-disconnect warning that used to format a log line from the event
+callback is now deferred and printed from `NetworkSystem::loop()`. This keeps
+the system event task callback lightweight while preserving the firmware console
+warning.
+
+## Verification
+
+After flashing Axiom009 with the fix, three real Web Bluetooth connection runs
+completed successfully using `Axiom009_adcf1e`.
+
+Serial evidence from the fixed firmware:
+
+- BLE connect: all three handlers unregistered with `ESP_OK`
+- WiFi paused: active handler count returned to `0`
+- BLE disconnect / WiFi resume: exactly three handlers registered again
+- Post-resume `WIFI_EVENT_STA_START`: callback delta stayed at `1`
+- No panic, assert, or `sys_evt` stack overflow occurred after the flash
+
+The remaining `sys_evt` high-water mark was still low during WiFi/IP events, so
+the code should continue to avoid formatted logging or heavy work in ESP event
+callbacks.
+
+After the temporary revert sanity test, the smaller production fix was reapplied,
+built, flashed, and checked again on 2026-05-04. Two real Web Bluetooth presence
+runs passed and the serial capture contained no panic, assert, reboot, or
+`sys_evt` stack-overflow signature. The capture did show an unrelated
+post-reconnect mDNS warning (`Service already exists`) that did not reboot the
+device.

--- a/devdocs/offline-data-logging-jsonl-devinfo-fix.md
+++ b/devdocs/offline-data-logging-jsonl-devinfo-fix.md
@@ -1,0 +1,83 @@
+# Offline Data Logging JSONL Devinfo Fix
+
+## Date
+
+2026-04-29
+
+## Context
+
+The Axiom Experiment App batch 6 ODL e2e test added a raw JSONL smoke test:
+
+- connect to Axiom over BLE;
+- open the offline data logging workspace;
+- select only LSM6DS;
+- capture a short raw JSONL log;
+- preview the saved log as raw text;
+- download the log through the UI;
+- parse every line as JSON.
+
+The first test run captured and downloaded the expected `.jsonl` file, but JSON
+parsing failed on the `devinfo` line.
+
+## Symptom
+
+The failing JSONL record contained a plug-and-play device info object with
+`poll` encoded as a quoted string while its value was already JSON:
+
+```json
+"poll":"{"c":"..."}"
+```
+
+That makes the overall line invalid JSON. Any JSONL consumer that parses each
+line with `JSON.parse` fails before it can inspect later data records.
+
+## Root Cause
+
+`DeviceTypeRecord::getJson(true)` builds the plug-and-play device type JSON.
+Before this fix it concatenated several fields directly into JSON strings:
+
+- `type`
+- `addr`
+- `det`
+- `init`
+- `poll`
+
+`pollInfo` is JSON content, not plain text, so wrapping it in quotes corrupts
+the JSON object. The other string fields were also inserted without JSON string
+escaping, so a quote or backslash in any field could corrupt the same JSONL
+record.
+
+## Fix
+
+`components/core/DeviceTypes/DeviceTypeRecord.h` now:
+
+- includes `RaftUtils.h`;
+- escapes string fields with `Raft::escapeString(value, true)`;
+- emits `poll` as a nested JSON object instead of a quoted raw string;
+- preserves the existing object insertion behavior for `devInfoJson`.
+
+This keeps raw JSONL logs parseable while preserving the same semantic fields in
+the `devinfo` record.
+
+## Verification
+
+Built and flashed Axiom009 with local Raft libraries:
+
+```sh
+raft build --no-docker -s Axiom009 -c
+raft flash -s Axiom009 --port /dev/cu.usbmodem2101
+```
+
+Then reran the app-side real BLE JSONL smoke test:
+
+```sh
+BLE_DEVICE_REGEX='Axiom009' npm run test:e2e:offline-logging-jsonl-raw-real
+```
+
+The test passed. The captured JSONL contained:
+
+- 1 header record;
+- 1 valid `devinfo` record;
+- 5 valid raw LSM6DS data records;
+- a `.jsonl` saved-log file that previewed as raw text, downloaded through the
+  UI, parsed successfully, and was deleted after validation.


### PR DESCRIPTION
## Title

Fix JSONL devinfo formatting and WiFi pause event handler cleanup

## Summary

This fixes two RaftCore issues found during Axiom offline logging and BLE/WiFi coexistence testing.

- Make device `devinfo` JSON valid in raw JSONL logs by escaping string fields and emitting `poll` as JSON instead of a quoted JSON string.
- Fix WiFi pause/resume cleanup by storing ESP-IDF event handler instance handles and unregistering those exact handles on WiFi stop.
- Defer WiFi disconnect warning logs out of the ESP event callback path so low-stack `sys_evt` work stays lightweight.

## Changes

### JSONL devinfo formatting

`DeviceTypeRecord::getJson(true)` now escapes string fields with `Raft::escapeString(...)` and preserves `pollInfo` as nested JSON. This prevents invalid JSONL records such as:

```json
"poll":"{"c":"..."}"